### PR TITLE
Exit plymouth when we hit mount-ro rather than localmount.

### DIFF
--- a/plymouth.c
+++ b/plymouth.c
@@ -240,7 +240,7 @@ int rc_plugin_hook(RC_HOOK hook, const char *name)
 
     case RC_HOOK_SERVICE_STOP_IN:
         /* Quit Plymouth when we're going to lost write access to /var/... */
-        if(strcmp(name, "localmount") == 0 &&
+        if(strcmp(name, "mount-ro") == 0 &&
                 strcmp(runlevel, RC_LEVEL_SHUTDOWN) == 0) {
             DBG("ply_quit(PLY_MODE_SHUTDOWN)");
             if(!ply_quit(PLY_MODE_SHUTDOWN))


### PR DESCRIPTION
Newer versions of openrc appear to run localmount almost immediately upon shutdown, causing the plugin to send Plymouth the quit command before the splash is even displayed, resulting in no splash on shutdown.

The job that cuts us off from writing to /var is now mount-ro, which runs near the end like it should and gives Plymouth time to show the splash.